### PR TITLE
Update list_ports_osx.py

### DIFF
--- a/serial/tools/list_ports_osx.py
+++ b/serial/tools/list_ports_osx.py
@@ -28,8 +28,8 @@ import ctypes.util
 
 from serial.tools import list_ports_common
 
-iokit = ctypes.cdll.LoadLibrary(ctypes.util.find_library('IOKit'))
-cf = ctypes.cdll.LoadLibrary(ctypes.util.find_library('CoreFoundation'))
+iokit = ctypes.cdll.LoadLibrary("/System/Library/Frameworks/IOKit.framework/Versions/Current/IOKit")
+cf = ctypes.cdll.LoadLibrary("/System/Library/Frameworks/CoreFoundation.framework/Versions/Current/CoreFoundation")
 
 kIOMasterPortDefault = ctypes.c_void_p.in_dll(iokit, "kIOMasterPortDefault")
 kCFAllocatorDefault = ctypes.c_void_p.in_dll(cf, "kCFAllocatorDefault")


### PR DESCRIPTION
Added macOS Big Sur support, as Big Sur removes access to Apple's Frameworks to the user, making os.path.isfile() fail.
os.path.isfile reads differently than direct file access.
The user doesn't have access to the Frameworks because of this -> https://www.reddit.com/r/MacOSBeta/comments/hfknpa/is_corefoundation_missing_for_everyone_on_big_sur/